### PR TITLE
Fix AddTemplateHotbar(): loading action spells

### DIFF
--- a/conf/mod_ptr_template.conf.dist
+++ b/conf/mod_ptr_template.conf.dist
@@ -30,7 +30,7 @@ LevelEnable = true
 #   TemplateDK
 #   TemplateEquipGear
 #   TemplateHomebind
-#   TemplateHotbar       - false
+#   TemplateHotbar
 #   TemplateLevel
 #   TemplateQuests       - false
 #   TemplateReputation
@@ -48,7 +48,7 @@ TemplateBagGear      = true
 TemplateDK           = true
 TemplateEquipGear    = true
 TemplateHomebind     = true
-TemplateHotbar       = false
+TemplateHotbar       = true
 TemplateLevel        = true
 TemplateQuests       = false
 TemplateReputation   = true

--- a/src/ptr_template.cpp
+++ b/src/ptr_template.cpp
@@ -580,9 +580,9 @@ private:
                 else
                     LOG_ERROR("module", "Failed to add hotbar spell {} on button {} with type {} for template character {}.", actionEntry, buttonEntry, typeEntry, player->GetGUID().ToString());
             } while (barInfo->NextRow());
-            player->SendActionButtons(1);
         }
         player->SaveToDB(false, false); // Commit action buttons.
+        player->SendActionButtons(1);
     }
 
     static void AddTemplateLevel(Player* player, uint32 index)

--- a/src/ptr_template.cpp
+++ b/src/ptr_template.cpp
@@ -566,7 +566,7 @@ private:
         {
             player->removeActionButton(j);
         }
-        //                                                0       1      2
+        //                                                  0       1      2
         QueryResult barInfo = WorldDatabase.Query("SELECT Button, Action, Type FROM mod_ptrtemplate_action WHERE (ID = {} AND RaceMask & {} AND ClassMask & {})", index, player->getRaceMask(), player->getClassMask());
         if (barInfo)
         {
@@ -582,7 +582,7 @@ private:
             } while (barInfo->NextRow());
             player->SendActionButtons(1);
         }
-        player->SaveToDB(false, false); // commit action buttons
+        player->SaveToDB(false, false); // Commit action buttons.
     }
 
     static void AddTemplateLevel(Player* player, uint32 index)

--- a/src/ptr_template.cpp
+++ b/src/ptr_template.cpp
@@ -561,14 +561,15 @@ private:
     }
 
     static void AddTemplateHotbar(Player* player, uint32 index)
-    { //                                                    0       1      2
+    {
+        for (uint8 j = ACTION_BUTTON_BEGIN; j <= MAX_ACTION_BUTTONS; j++)
+        {
+            player->removeActionButton(j);
+        }
+        //                                                0       1      2
         QueryResult barInfo = WorldDatabase.Query("SELECT Button, Action, Type FROM mod_ptrtemplate_action WHERE (ID = {} AND RaceMask & {} AND ClassMask & {})", index, player->getRaceMask(), player->getClassMask());
         if (barInfo)
         {
-            for (uint8 j = ACTION_BUTTON_BEGIN; j <= MAX_ACTION_BUTTONS; j++)
-            {
-                player->removeActionButton(j);
-            }
             do
             {
                 uint8 buttonEntry = (*barInfo)[0].Get<uint8>();

--- a/src/ptr_template.cpp
+++ b/src/ptr_template.cpp
@@ -54,7 +54,7 @@ public:
         {
             itemRoutine = METHOD_DELETE;
         }
-        
+
         scheduler.Schedule(Milliseconds(delayMultiplier * APPLY_DELAY), [player, index, itemRoutine](TaskContext context)
             {
                 switch (context.GetRepeatCounter())
@@ -467,7 +467,7 @@ private:
         {
             return;
         }
-            
+
         int STARTER_QUESTS[33] = { 12593, 12619, 12842, 12848, 12636, 12641, 12657, 12678, 12679, 12680, 12687, 12698, 12701, 12706, 12716, 12719, 12720, 12722, 12724, 12725, 12727, 12733, -1, 12751, 12754, 12755, 12756, 12757, 12779, 12801, 13165, 13166 };
         // Blizz just dumped all of the special surprise quests on every DK template. Don't know yet if I want to do the same.
         int specialSurpriseQuestId = -1;
@@ -560,25 +560,28 @@ private:
         }
     }
 
-    static void AddTemplateHotbar(Player* player, uint32 index) // Someone smarter than me needs to fix this.
+    static void AddTemplateHotbar(Player* player, uint32 index)
     { //                                                    0       1      2
         QueryResult barInfo = WorldDatabase.Query("SELECT Button, Action, Type FROM mod_ptrtemplate_action WHERE (ID = {} AND RaceMask & {} AND ClassMask & {})", index, player->getRaceMask(), player->getClassMask());
-        for (uint8 j = ACTION_BUTTON_BEGIN; j <= MAX_ACTION_BUTTONS; j++) // This is supposed to go through every available action slot and remove what's there.
-        { //                                                                 This doesn't work for spells added by AddTemplateSpells.
-            player->removeActionButton(j); //                                I don't know why and I've tried everything I can think of, but nothing's worked.
-        } //                                                                 And yes, I do want the hotbar cleared for characters that don't have any hotbar data in the template.
         if (barInfo)
         {
+            for (uint8 j = ACTION_BUTTON_BEGIN; j <= MAX_ACTION_BUTTONS; j++)
+            {
+                player->removeActionButton(j);
+            }
             do
             {
                 uint8 buttonEntry = (*barInfo)[0].Get<uint8>();
                 uint32 actionEntry = (*barInfo)[1].Get<uint32>();
                 uint8 typeEntry = (*barInfo)[2].Get<uint8>();
-                player->addActionButton(buttonEntry, actionEntry, typeEntry);
-                LOG_DEBUG("module", "Added hotbar spell {} on button {} with type {} for template character {}.", actionEntry, buttonEntry, typeEntry, player->GetGUID().ToString());
+                if (player->addActionButton(buttonEntry, actionEntry, typeEntry))
+                    LOG_DEBUG("module", "Added hotbar spell {} on button {} with type {} for template character {}.", actionEntry, buttonEntry, typeEntry, player->GetGUID().ToString());
+                else
+                    LOG_ERROR("module", "Failed to add hotbar spell {} on button {} with type {} for template character {}.", actionEntry, buttonEntry, typeEntry, player->GetGUID().ToString());
             } while (barInfo->NextRow());
+            player->SendActionButtons(1);
+            player->SaveToDB(false, false); // commit action buttons
         }
-        player->SendActionButtons(2);
     }
 
     static void AddTemplateLevel(Player* player, uint32 index)
@@ -868,7 +871,7 @@ private:
                     item->DeleteFromInventoryDB(trans);
                     vestigialEquipItems.push_back(item);
                 }
-                
+
                 while (!vestigialEquipItems.empty())
                 {
                     std::string subject = player->GetSession()->GetModuleString(module_string, MAIL_BOOST_SUBJECT)[0];

--- a/src/ptr_template.cpp
+++ b/src/ptr_template.cpp
@@ -581,8 +581,8 @@ private:
                     LOG_ERROR("module", "Failed to add hotbar spell {} on button {} with type {} for template character {}.", actionEntry, buttonEntry, typeEntry, player->GetGUID().ToString());
             } while (barInfo->NextRow());
             player->SendActionButtons(1);
-            player->SaveToDB(false, false); // commit action buttons
         }
+        player->SaveToDB(false, false); // commit action buttons
     }
 
     static void AddTemplateLevel(Player* player, uint32 index)


### PR DESCRIPTION
## changes
Add actions from db

## details
- `SendActionButtons(2)` clears all actions. 1 commits it
0 didn't work. No need to send (2) then (1).
- `SaveToDB()` is required to commit actions to db. it calls `_saveActions()`

## test

option need to be enabled in the module config

the data is wrong in DB. I did not apply any optional sql. I only found action related data in the default.
template 1 is disabled, has actions, but no spells
 template 2 is enabled, has spells, but has no actions
so, use actions from id 1 and test with 2 
`UPDATE acore_world.mod_ptrtemplate_action SET id = 2;`

level 80 druid (or warrior)
1. `.apply template 2`
2. check if it matches DB actions
3. relog and see if spells are still there

## TODO
 fix action data, 
for druid bear form spells are set in the wrong form, but they're loaded at least

