### PR TITLE
disable template application on login if the module is disabled by config

### DIFF
--- a/src/ptr_template.cpp
+++ b/src/ptr_template.cpp
@@ -980,6 +980,11 @@ public:
     {
         static createTemplate templatevar;
 
+        if (!sConfigMgr->GetOption<bool>("TemplateEnable", true))
+        {
+            return;
+        }
+
         if (sConfigMgr->GetOption<bool>("AnnounceEnable", true))
         {
             ChatHandler(player->GetSession()).PSendModuleSysMessage(module_string, templatevar.ALERT_MODULE_PRESENCE);


### PR DESCRIPTION
With the config below, templates are applied on login

```
#
#    TemplateEnable
#        Description: Enable the application of templates.
#        Default:     true  - (Enabled)
#                     false - (Disabled)

TemplateEnable = false

#
#    LoginTemplateIndex
#        Description: Template index to automatically apply to characters on first login.
#        Default:     0 - (Disabled, no template will be applied)

LoginTemplateIndex = 2
```

with the change, this will no longer occur

